### PR TITLE
Custom log format

### DIFF
--- a/src/RecurrentTasks/LogFormat.cs
+++ b/src/RecurrentTasks/LogFormat.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RecurrentTasks
+{
+    public class LogFormat
+    {
+        public string Format { get; private set; }
+        public object[] Args { get; private set; }
+
+        public LogFormat(string format, params object[] args)
+        {
+            Format = format;
+            Args = args;
+        }
+    }
+}

--- a/src/RecurrentTasks/Logger.cs
+++ b/src/RecurrentTasks/Logger.cs
@@ -1,6 +1,10 @@
 ﻿namespace RecurrentTasks
 {
     using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Reflection;
     using Microsoft.Extensions.Logging;
 
     internal class Logger : ILogger
@@ -33,7 +37,48 @@
             }
             else
             {
+                if (options.LogFormatter != null)
+                {
+                    var logFormat = GetLogFormat<TState>(state);
+                    logFormat = options.LogFormatter(logFormat.Format, logFormat.Args);
+
+                    var stateArgs = new object[] {
+                        logFormat.Format,
+                        logFormat.Args
+                    };
+
+                    state = (TState)Activator.CreateInstance(state.GetType(), stateArgs);
+                }
+
                 this.logger.Log<TState>(logLevel, eventId, state, exception, formatter);
+            }
+        }
+
+        private LogFormat GetLogFormat<TState>(TState state)
+        {
+
+            var stateFields = state.GetType().GetRuntimeFields();
+
+            var args = (object[])stateFields.FirstOrDefault(o => o.Name == "_values")?
+                                            .GetValue(state);
+
+            var originalMessage = (string)stateFields.FirstOrDefault(o => o.Name == "_originalMessage")?
+                                                     .GetValue(state);
+
+            var stateFormatter = stateFields.FirstOrDefault(o => o.Name == "_formatter")
+                                            .GetValue(state);
+  
+            if (args == null || args.Length == 0 || stateFormatter == null)
+            {
+                return new LogFormat(originalMessage, args);
+            }
+            else
+            {
+                var formatterProperties = stateFormatter.GetType().GetRuntimeProperties();
+
+                var originalFormat = (string)formatterProperties.FirstOrDefault(o => o.Name == "OriginalFormat")?.GetValue(stateFormatter);
+
+                return new LogFormat(originalFormat, args);
             }
         }
     }

--- a/src/RecurrentTasks/Logger.cs
+++ b/src/RecurrentTasks/Logger.cs
@@ -1,0 +1,40 @@
+﻿namespace RecurrentTasks
+{
+    using System;
+    using Microsoft.Extensions.Logging;
+
+    internal class Logger : ILogger
+    {
+        private readonly ILogger logger;
+
+        private readonly TaskOptions options;
+
+        public Logger(ILogger logger, TaskOptions options)
+        {
+            this.logger = logger;
+            this.options = options;
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return this.logger.BeginScope<TState>(state);
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return this.logger.IsEnabled(logLevel);
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (options.DisableLogger)
+            {
+                // Do nothing
+            }
+            else
+            {
+                this.logger.Log<TState>(logLevel, eventId, state, exception, formatter);
+            }
+        }
+    }
+}

--- a/src/RecurrentTasks/TaskOptions.cs
+++ b/src/RecurrentTasks/TaskOptions.cs
@@ -81,5 +81,8 @@
         /// Disable the task's internal logger
         /// </summary>
         public bool DisableLogger { get; set; }
+
+        public delegate LogFormat LogFormatterDelegate(string format, params object[] args);
+        public LogFormatterDelegate LogFormatter;
     }
 }

--- a/src/RecurrentTasks/TaskOptions.cs
+++ b/src/RecurrentTasks/TaskOptions.cs
@@ -76,5 +76,10 @@
         public Func<IServiceProvider, ITask, Task> AfterRunSuccess { get; set; }
 
         public Func<IServiceProvider, ITask, Exception, Task> AfterRunFail { get; set; }
+
+        /// <summary>
+        /// Disable the task's internal logger
+        /// </summary>
+        public bool DisableLogger { get; set; }
     }
 }

--- a/src/RecurrentTasks/TaskRunner.cs
+++ b/src/RecurrentTasks/TaskRunner.cs
@@ -13,7 +13,7 @@
     {
         private readonly EventWaitHandle runImmediately = new AutoResetEvent(false);
 
-        private readonly ILogger logger;
+        private readonly Logger logger;
 
         private Task mainTask;
 
@@ -42,7 +42,9 @@
                 throw new ArgumentNullException(nameof(serviceScopeFactory));
             }
 
-            this.logger = loggerFactory.CreateLogger($"{this.GetType().Namespace}.{nameof(TaskRunner<TRunnable>)}<{typeof(TRunnable).FullName}>");
+            var originLogger = loggerFactory.CreateLogger($"{this.GetType().Namespace}.{nameof(TaskRunner<TRunnable>)}<{typeof(TRunnable).FullName}>");
+            logger = new Logger(originLogger, options);
+
             Options = options;
             ServiceScopeFactory = serviceScopeFactory;
             RunStatus = new TaskRunStatus();
@@ -286,6 +288,18 @@
             catch (Exception ex2)
             {
                 logger.LogError(0, ex2, "Error while processing AfterRunFail event (ignored)");
+            }
+        }
+
+        private ILogger GetLogger()
+        {
+            if (Options.DisableLogger)
+            {
+                return null;
+            }
+            else
+            {
+                return logger;
             }
         }
     }

--- a/src/RecurrentTasks/TaskRunner.cs
+++ b/src/RecurrentTasks/TaskRunner.cs
@@ -290,17 +290,5 @@
                 logger.LogError(0, ex2, "Error while processing AfterRunFail event (ignored)");
             }
         }
-
-        private ILogger GetLogger()
-        {
-            if (Options.DisableLogger)
-            {
-                return null;
-            }
-            else
-            {
-                return logger;
-            }
-        }
     }
 }


### PR DESCRIPTION
In my project, I have to follow a log pattern but I do not want to touch the current log messages in the lib.
So I added a custom formatter delegate allowing to custom the log's format.

Example usage:
```csharp
services.AddTask<MyService>(option => {
  option.LogFormatter = (format, args) =>
  {
      var newFormat = string.Format("{{@Group}} {{@Action}} {0}", format);
      var newArgs = new object[] {
          "GroupA",
          "ActionB"
      }.Concat(args).ToArray();
  
      return new RecurrentTasks.LogFormat(newFormat, newArgs);
  };
}, ServiceLifetime.Singleton);
```